### PR TITLE
Add soundfile driver

### DIFF
--- a/create_standalone_bundle.sh
+++ b/create_standalone_bundle.sh
@@ -5,5 +5,7 @@
 MAIN_SCRIPT="pysdrweb/server/main.py"
 CURR_DIR=`pwd`
 
-pyinstaller ${MAIN_SCRIPT} -n sdr_server -p ${CURR_DIR} --add-data "pysdrweb/static/*:pysdrweb/static"
+pyinstaller ${MAIN_SCRIPT} -n sdr_server -p ${CURR_DIR} \
+  --add-data "pysdrweb/static/*:pysdrweb/static" \
+  --hidden-import "soundfile"
 

--- a/pysdrweb/driver/common.py
+++ b/pysdrweb/driver/common.py
@@ -43,7 +43,9 @@ async def close_pipe_on_exit(proc, fd):
 class AbstractRtlDriver(object):
 
     def __init__(self, formats):
-        self._supported_formats = frozenset(formats)
+        self._supported_formats = frozenset([
+            format.upper() for format in formats
+        ])
         self._processes = []
         self._futures = []
         self._shutdown_hooks = []

--- a/pysdrweb/driver/common.py
+++ b/pysdrweb/driver/common.py
@@ -127,7 +127,7 @@ class AbstractRtlDriver(object):
         # Start the process up again.
         await self.start(self._frequency)
 
-    async def process_request(self, req_handler, fmt):
+    async def process_request(self, req_handler, fmt, timeout):
         raise NotImplementedError()
 
 

--- a/pysdrweb/driver/icecast.py
+++ b/pysdrweb/driver/icecast.py
@@ -139,7 +139,7 @@ class IcecastRtlFMDriver(AbstractRtlDriver):
 
         self._frequency = frequency
 
-    async def process_request(self, req_handler, fmt):
+    async def process_request(self, req_handler, fmt, timeout):
         # Proxy this request to the icecast server. This currently only
         # supports GET, since that is all that should be necessary.
         #

--- a/pysdrweb/driver/rtl_native.py
+++ b/pysdrweb/driver/rtl_native.py
@@ -192,16 +192,7 @@ class RtlFMNativeDriver(AbstractRtlDriver):
             self._wait_to_join_queues()
         ))
 
-    async def process_request(self, req_handler, fmt):
-        # Extract any timeout parameter.
-        try:
-            timeout = req_handler.get_argument('timeout', None)
-            if timeout is not None:
-                timeout = float(timeout)
-        except Exception:
-            req_handler.set_status(400)
-            req_handler.finish()
-            return
+    async def process_request(self, req_handler, fmt, timeout):
         # Check for other formats first, because 'WAV' and 'AIFF' are handled
         # almost identically.
         writer = None
@@ -242,7 +233,7 @@ class RtlFMNativeDriver(AbstractRtlDriver):
                 writer.setframerate(48000)
                 writer.setnframes(48000000)
                 writer.setcomptype(b'G722', b'G.722 Compression.')
-                req_handler.set_header('Content-Type', 'audio/aifc')
+                req_handler.set_header('Content-Type', 'audio/aiff')
             else:
                 raise UnsupportedFormatError(
                     'Format ({}) not supported by this driver!'.format(fmt))
@@ -267,66 +258,3 @@ class RtlFMNativeDriver(AbstractRtlDriver):
         finally:
             if writer:
                 writer.close()
-
-    # async def _write_wav_format(self, req_handler):
-    #     writer = None
-    #     try:
-    #         file_handle = RequestFileHandle(req_handler)
-    #         writer = wave.open(file_handle, 'wb')
-
-    #         # Set the content type for this handler.
-    #         req_handler.set_header('Content-Type', 'audio/wav')
-    #         # Set the common parameters for the writer here.
-    #         #
-    #         # 1 channel (Mono)
-    #         # 2 byte width sample
-    #         # 48k framerate
-    #         # 48000000 is an arbitrarily large number of frames.
-    #         # 'NONE' compression type.
-    #         # None for the compression name.
-    #         writer.setparams((1, 2, 48000, 0, 'NONE', None))
-
-    #         async for pcm_data in self.data_generator():
-    #             writer.writeframesraw(pcm_data)
-    #             await req_handler.flush()
-    #     except iostream.StreamClosedError:
-    #         # Done because the connection is closed, so just exit.
-    #         return
-    #     finally:
-    #         if writer:
-    #             writer.close()
-
-    # async def _write_aiff_format(self, req_handler):
-    #     writer = None
-    #     try:
-    #         file_handle = RequestFileHandle(req_handler)
-    #         writer = aifc.open(file_handle, 'wb')
-
-    #         # Set the content type for this handler.
-    #         req_handler.set_header('Content-Type', 'audio/wav')
-    #         # Set the common parameters for the writer here.
-    #         #
-    #         # 1 channel (Mono)
-    #         # 2 byte width sample
-    #         # 48k framerate
-    #         # 48000000 is an arbitrarily large number of frames.
-    #         # 'NONE' compression type.
-    #         # None for the compression name.
-    #         writer.setparams((1, 2, 48000, 0, 'NONE', None))
-
-    #         async for pcm_data in self.data_generator():
-    #             writer.writeframesraw(pcm_data)
-    #             await req_handler.flush()
-    #     except iostream.StreamClosedError:
-    #         # Done because the connection is closed, so just exit.
-    #         return
-    #     except Exception:
-    #         logger.exception('Unexpected error when writing to AIF%s format!',
-    #                          'C' if compressed else 'F')
-    #         # Do nothing, because we cannot signal the error after a 200
-    #         # status code. The error is (potentially) benign anyway, but not
-    #         # always, so log it.
-    #         return
-    #     finally:
-    #         if writer:
-    #             writer.close()

--- a/pysdrweb/server/handlers.py
+++ b/pysdrweb/server/handlers.py
@@ -76,8 +76,17 @@ class ProcessAudioHandler(BaseRequestHandler):
         if ext.startswith('.'):
             ext = ext[1:]
         driver = self.get_driver()
+
         try:
-            await driver.process_request(self, ext)
+            timeout = req_handler.get_argument('timeout', None)
+            if timeout is not None:
+                timeout = float(timeout)
+        except Exception:
+            req_handler.send_status(400, "Bad 'timeout' parameter!")
+            return
+
+        try:
+            await driver.process_request(self, ext, timeout)
         except UnsupportedFormatError as exc:
             self.send_status(400, str(exc))
         except Exception:

--- a/pysdrweb/static/index.html
+++ b/pysdrweb/static/index.html
@@ -1,68 +1,70 @@
 <!doctype html>
 <html lang="en">
 <head>
-	<meta charset="utf-8">
-	<title>RTL-SDR FM Radio</title>
+  <meta charset="utf-8">
+  <title>RTL-SDR FM Radio</title>
 </head>
 <body>
-	<h1>RTL-SDR FM Radio</h1>
-	<p>
-		Basic FM server that works as an FM Radio. It permits tuning
-		the station, and playing it back via the web browser.
-	</p>
-	<audio controls>
-		<source src="/api/radio.aifc" type="audio/aiff">
-		<source src="/api/radio.mp3" type="audio/mpeg">
-		<source src="/api/radio.wav" type="audio/wav">
-		Your browser does not support the audio tag.
-	</audio>
-	<div>
-		<h2>Tuner</h2>
-		<div>Current frequency: <span id="tuner-element"></span></div>
-		<form method="POST" action="/api/frequency">
-			<label for="change-freq">New Frequency:</label>
-			<input type="text" id="change-freq" name="frequency">
-			<input type="submit" value="Change Frequency">
-		</form>
-		<script type="text/javascript">
-			async function updateTuner() {
-				let data = {};
-				try {
-					res = await fetch('/api/frequency', {
-						method: 'GET'
-					});
-					data = await res.json()
-				} catch (e) {
-					console.error(e);
-					return;
-				}
-				const elem = document.getElementById('tuner-element')
-				elem.innerHTML = data.frequency;
-			}
-			updateTuner();
-		</script>
-	</div>
-	<div>
-		<h2>Log</h2>
-		<button id="log-refresh" onclick="updateLog();">Refresh</button>
-		<div id="log-element" style="white-space: pre-wrap;"></div>
-		<script type="text/javascript">
-			async function updateLog() {
-				let data = {};
-				try {
-					res = await fetch('/api/procinfo', {
-						method: 'GET'
-					});
-					data = await res.text()
-				} catch (e) {
-					console.error(e);
-					return;
-				}
-				const elem = document.getElementById('log-element')
-				elem.innerHTML = data.replace('\n', '<br />');
-			}
-			updateLog();
-		</script>
-	</div>
+  <h1>RTL-SDR FM Radio</h1>
+  <p>
+    Basic FM server that works as an FM Radio. It permits tuning
+    the station, and playing it back via the web browser.
+  </p>
+  <audio controls>
+    <source src="/api/radio/audio.flac" type="audio/flac">
+    <source src="/api/radio/audio.ogg" type="audio/ogg">
+    <source src="/api/radio/audio.mp3" type="audio/mpeg">
+    <source src="/api/radio/audio.aifc" type="audio/aiff">
+    <source src="/api/radio/audio.wav" type="audio/wav">
+    Your browser does not support the audio tag.
+  </audio>
+  <div>
+    <h2>Tuner</h2>
+    <div>Current frequency: <span id="tuner-element"></span></div>
+    <form method="POST" action="/api/frequency">
+      <label for="change-freq">New Frequency:</label>
+      <input type="text" id="change-freq" name="frequency">
+      <input type="submit" value="Change Frequency">
+    </form>
+    <script type="text/javascript">
+      async function updateTuner() {
+        let data = {};
+        try {
+          res = await fetch('/api/frequency', {
+            method: 'GET'
+          });
+          data = await res.json()
+        } catch (e) {
+          console.error(e);
+          return;
+        }
+        const elem = document.getElementById('tuner-element')
+        elem.innerHTML = data.frequency;
+      }
+      updateTuner();
+    </script>
+  </div>
+  <div>
+    <h2>Log</h2>
+    <button id="log-refresh" onclick="updateLog();">Refresh</button>
+    <div id="log-element" style="white-space: pre-wrap;"></div>
+    <script type="text/javascript">
+      async function updateLog() {
+        let data = {};
+        try {
+          res = await fetch('/api/procinfo', {
+            method: 'GET'
+          });
+          data = await res.text()
+        } catch (e) {
+          console.error(e);
+          return;
+        }
+        const elem = document.getElementById('log-element')
+        elem.innerHTML = data.replace('\n', '<br />');
+      }
+      updateLog();
+    </script>
+  </div>
 </body>
 </html>

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
         # Could possibly waive this to tornado 5.X, not sure.
         'tornado>=6.0.1',
         'PyYAML>=5.4.1',
-        'click>=5.0.0'
+        'click>=5.0.0',
+        'SoundFile>=0.10.0',
     ],
     setup_requires=['flake8'],
     entry_points={


### PR DESCRIPTION
This PR updates the `rtl_native` driver to optionally support more formats handled by python's `SoundFile` module, in particular OGG and FLAC. These formats are potentially compressed reducing total bandwidth needed for the server.

This also makes a few other internal improvements.