### PR TITLE
Refactor to asyncio.

### DIFF
--- a/src/python/pysdrweb/drivers/__init__.py
+++ b/src/python/pysdrweb/drivers/__init__.py
@@ -3,10 +3,10 @@
 Module for basic drivers to the RTL system.
 """
 
-from pysdrweb.drivers.base import AbstractRtlDriver
+from pysdrweb.drivers.base import AbstractPCMDriver
 from pysdrweb.drivers.rtl_fm import RtlFmExecDriver
 
 __all__ = [
-    "AbstractRtlDriver",
+    "AbstractPCMDriver",
     "RtlFmExecDriver",
 ]

--- a/src/python/pysdrweb/drivers/base.py
+++ b/src/python/pysdrweb/drivers/base.py
@@ -11,7 +11,7 @@ from collections import deque
 from pysdrweb.util import misc
 
 
-class AbstractRtlDriver(abc.ABC):
+class AbstractPCMDriver(abc.ABC):
     """Abstract driver that provides PCM data asynchronously."""
 
     def __init__(
@@ -22,7 +22,7 @@ class AbstractRtlDriver(abc.ABC):
         max_chunk_count=None,
         seq_index=0,
     ):
-        """Create the RtlDriver.
+        """Create the PCM driver using the passed metadata.
 
         'max_chunk_count' configures the maximum number of chunks to store,
         as each chunk would be added by "add_chunk()".

--- a/src/python/pysdrweb/drivers/rtl_fm.py
+++ b/src/python/pysdrweb/drivers/rtl_fm.py
@@ -6,10 +6,10 @@ Driver
 import shlex
 import asyncio
 from pysdrweb.util import misc
-from pysdrweb.drivers.base import AbstractRtlDriver
+from pysdrweb.drivers.base import AbstractPCMDriver
 
 
-class RtlFmExecDriver(AbstractRtlDriver):
+class RtlFmExecDriver(AbstractPCMDriver):
     """Driver that runs rtl_fm directly, then encodes the data on request.
 
     This driver basically runs:

--- a/src/python/pysdrweb/encoders/base.py
+++ b/src/python/pysdrweb/encoders/base.py
@@ -7,7 +7,7 @@ from typing import Optional, Callable, Awaitable
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from pysdrweb.util.misc import PCMBufferAddress
-from pysdrweb.drivers import AbstractRtlDriver
+from pysdrweb.drivers import AbstractPCMDriver
 
 
 class UnsupportedFormatError(Exception):
@@ -17,12 +17,12 @@ class UnsupportedFormatError(Exception):
 class BaseEncoder(ABC):
     """Base encoder class with the different properties"""
 
-    def __init__(self, driver: AbstractRtlDriver) -> None:
+    def __init__(self, driver: AbstractPCMDriver) -> None:
         super().__init__()
         self._driver = driver
 
     @property
-    def driver(self) -> AbstractRtlDriver:
+    def driver(self) -> AbstractPCMDriver:
         return self._driver
 
     @classmethod

--- a/src/python/pysdrweb/encoders/lame_mp3.py
+++ b/src/python/pysdrweb/encoders/lame_mp3.py
@@ -9,14 +9,14 @@ from typing import Awaitable, Callable
 import lameenc
 from pysdrweb.util import misc
 from pysdrweb.encoders.base import BaseEncoder
-from pysdrweb.drivers import AbstractRtlDriver
+from pysdrweb.drivers import AbstractPCMDriver
 
 
 class Mp3Encoder(BaseEncoder):
 
     _supported_formats = ("MP3",)
 
-    def __init__(self, driver: AbstractRtlDriver, quality=7) -> None:
+    def __init__(self, driver: AbstractPCMDriver, quality=7) -> None:
         super().__init__(driver)
         self.quality = quality
 

--- a/src/python/pysdrweb/encoders/soundfile_util.py
+++ b/src/python/pysdrweb/encoders/soundfile_util.py
@@ -4,11 +4,10 @@ Encoders using python's 'soundfile' library.
 """
 
 from typing import BinaryIO, Optional
-from collections.abc import Sequence, Awaitable, Callable
+from collections.abc import Collection, Awaitable, Callable
 import math
 import soundfile
 from pysdrweb.util import misc
-from pysdrweb.drivers import AbstractRtlDriver
 from pysdrweb.encoders.base import UnsupportedFormatError, BaseEncoder
 
 # NOTE: The available formats that soundfile supports should be at:
@@ -24,7 +23,7 @@ class SoundfileEncoder(BaseEncoder):
     """Encoder that uses the ``soundfile`` module."""
 
     @classmethod
-    def get_supported_formats(cls) -> Sequence[str]:
+    def get_supported_formats(cls) -> Collection[str]:
         return _FORMAT_TYPES
 
     async def encode(

--- a/src/python/pysdrweb/fmserver/context.py
+++ b/src/python/pysdrweb/fmserver/context.py
@@ -8,9 +8,9 @@ import asyncio
 
 # Local Imports
 from pysdrweb.util.logger import logger
-from pysdrweb.util.auth import parse_auth_manager_from_options
+from pysdrweb.util.auth import parse_auth_manager_from_options, BaseAuthManager
 from pysdrweb.fmserver.hls_streaming import HLSManager
-from pysdrweb.drivers import RtlFmExecDriver
+from pysdrweb.drivers import RtlFmExecDriver, AbstractPCMDriver
 
 
 class FmServerContext:
@@ -26,8 +26,8 @@ class FmServerContext:
 
     def __init__(
         self,
-        driver,
-        auth_manager,
+        driver: AbstractPCMDriver,
+        auth_manager: BaseAuthManager,
         hls_manager: Optional[HLSManager] = None,
         default_frequency=None,
     ):
@@ -42,12 +42,12 @@ class FmServerContext:
         self._hls_manager = hls_manager
 
     @property
-    def driver(self):
+    def driver(self) -> AbstractPCMDriver:
         """Return the driver for this context."""
         return self._driver
 
     @property
-    def auth_manager(self):
+    def auth_manager(self) -> BaseAuthManager:
         """Return the AuthManager for this context."""
         return self._auth_manager
 

--- a/src/python/pysdrweb/fmserver/handlers.py
+++ b/src/python/pysdrweb/fmserver/handlers.py
@@ -18,6 +18,7 @@ from pysdrweb.encoders import (
     get_mime_type_for_format,
     UnsupportedFormatError,
 )
+from pysdrweb.drivers import AbstractPCMDriver
 from pysdrweb.fmserver import hls_streaming
 
 try:
@@ -69,13 +70,13 @@ class RequestFileHandle:
 
 
 class FmRequestHandler(web.RequestHandler):
-    """Base handler with common access to the AbstractRtlDriver."""
+    """Base handler with common access to the AbstractPCMDriver."""
 
     def initialize(self, context=None):
         """Initialize the handler with the current context."""
         self._context = context
 
-    def get_driver(self):
+    def get_driver(self) -> AbstractPCMDriver:
         """Get the FM driver for the handler."""
         return self.get_context().driver
 
@@ -83,7 +84,7 @@ class FmRequestHandler(web.RequestHandler):
         """Get the current FMServerContext for the handler."""
         return self._context
 
-    def send_status(self, code, message):
+    def send_status(self, code: int, message: str):
         """Helper to send a JSON message for the given status."""
         self.set_status(code)
         self.write({"status": code, "message": message})

--- a/src/python/pysdrweb/fmserver/hls_streaming.py
+++ b/src/python/pysdrweb/fmserver/hls_streaming.py
@@ -3,6 +3,7 @@
 Module with objects to handle HLS streaming.
 """
 
+from typing import Optional
 import io
 import asyncio
 from collections import OrderedDict
@@ -28,7 +29,14 @@ logger = get_child_logger("hls")
 class HLSManager:
     """Manager that encodes an incoming (PCM) stream into an HLS format."""
 
-    def __init__(self, driver, count=3, secs_per_chunk=10, fmt=None, start_index=1):
+    def __init__(
+        self,
+        driver,
+        count: int = 3,
+        secs_per_chunk: float = 10,
+        fmt: Optional[str] = None,
+        start_index: int = 1,
+    ):
         """Create the HLSManager that writes audio files for HLS streaming.
 
         HLS Streaming involves taking a continuous stream of media, then

--- a/src/python/pysdrweb/util/auth.py
+++ b/src/python/pysdrweb/util/auth.py
@@ -2,7 +2,6 @@
 
 Authentication utilities for RequestHandlers.
 """
-
 import base64
 from functools import wraps
 from pysdrweb.util.logger import auth_logger
@@ -39,7 +38,7 @@ class BaseAuthManager:
         """Return whether to ignore authentication for 'read' requests."""
         return self._ignore_on_read
 
-    def authenticate(self, token):
+    def authenticate(self, req_handler):
         """Return the user this request is authenticated for.
 
         If not authenticated by this manager, this should raise some form

--- a/src/python/pysdrweb/util/auth.py
+++ b/src/python/pysdrweb/util/auth.py
@@ -2,6 +2,7 @@
 
 Authentication utilities for RequestHandlers.
 """
+
 import base64
 from functools import wraps
 from pysdrweb.util.logger import auth_logger


### PR DESCRIPTION
This PR moves away from `tornado.ioloop` and more to `asyncio` and native event loop management.

This also improves some class naming to be more accurate and adds typing annotations in some cases.